### PR TITLE
Correction division

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -36,4 +36,4 @@ def divide(a,b):
         :param int b: second operand
         :return: int: Result of the division a/b
     """
-    return a // b  # Division in the right order
+    return a / b  # Division in the right order


### PR DESCRIPTION
Le test test_divide échouait : la fonction divide(a, b) utilisait la division entière (a // b) au lieu de la division réelle (a / b).